### PR TITLE
Added an intellisence workaround

### DIFF
--- a/CS/XpoSerialization/Startup.cs
+++ b/CS/XpoSerialization/Startup.cs
@@ -22,7 +22,7 @@ namespace XpoSerialization
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
                 .AddDxSampleModelJsonOptions();
             services.AddCors();
-            services.AddXpoDefaultUnitOfWork(true, options =>
+            services.AddXpoDefaultUnitOfWork(true, (DataLayerOptionsBuilder options) =>
                 options.UseConnectionString(Configuration.GetConnectionString("MSSqlServer"))
                 // .UseAutoCreationOption(AutoCreateOption.DatabaseAndSchema) // debug only
                 .UseEntityTypes(typeof(Customer), typeof(Order)));

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ Use the following steps to create a project or refer to the [original tutorial](
   ```cs
   public void ConfigureServices(IServiceCollection services) {
     services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
-    services.AddXpoDefaultUnitOfWork(true, options =>
+    services.AddXpoDefaultUnitOfWork(true, (DataLayerOptionsBuilder options) =>
         options.UseConnectionString(Configuration.GetConnectionString("MsSqlServer"))
         .UseEntityTypes(typeof(Customer), typeof(Order)));
   }


### PR DESCRIPTION
The `AddXpoDefaultUnitOfWork` method has 3 overloads:

    public static IServiceCollection AddXpoDefaultUnitOfWork(this IServiceCollection serviceCollection, bool useDataLayerAsSingletone, Action<DataLayerOptionsBuilder> dataLayerOptionsBuildAction);
    public static IServiceCollection AddXpoDefaultUnitOfWork(this IServiceCollection serviceCollection, bool useDataLayerAsSingletone, Func<IServiceProvider, IDataLayer> dataLayerFactory);
    public static IServiceCollection AddXpoDefaultUnitOfWork(this IServiceCollection serviceCollection, bool useObjectLayerAsSingleton, Func<IServiceProvider, IObjectLayer> objectLayerFactory);

Visual studio cannot determine the last parameter type until you use any method explicitly. To make an intellisense work, one should declare the argument type.